### PR TITLE
chore(devops): define and document environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,16 @@
+# DATABASE
 DB_SA_PASSWORD=YourStrongPassword123!
-
 CONNECTION_STRING=Server=db,1433;Database=TaskMateDb;User Id=sa;Password=YourStrongPassword123!;TrustServerCertificate=True;Encrypt=False;
 
+# JWT
 JWT_KEY=your_jwt_secret_here
 JWT_ISSUER=TaskMate.API
 JWT_AUDIENCE=TaskMate.Client
 JWT_EXPIRES_IN_HOURS=24
 
+# API
+BACKEND_URL=http://localhost:5048
 VITE_API_URL=http://localhost:5048/api
 
+# DOCKER
 ACCEPT_EULA=Y

--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
-# taskmate-app
+## Environment Variables
+
+This project uses environment variables for local configuration.
+
+A `.env.example` file is provided at the project root.  
+Create a local `.env` file based on it before running the application.
+
+> Note: `.env` is ignored by Git and should not be committed.
+
+### Setup
+
+Copy `.env.example` to `.env` and adjust the values if needed.
+
+Example variables included in the project:
+
+- `DB_SA_PASSWORD` – SQL Server password used by the database container
+- `CONNECTION_STRING` – database connection string used by the backend
+- `JWT_KEY` – secret key used to sign JWT tokens
+- `JWT_ISSUER` – JWT issuer value
+- `JWT_AUDIENCE` – JWT audience value
+- `JWT_EXPIRES_IN_HOURS` – token expiration time in hours
+- `BACKEND_URL` – backend base URL used for local development/documentation
+- `VITE_API_URL` – frontend API base URL used by the frontend application
+- `ACCEPT_EULA` – required variable for the SQL Server Docker container
+
+### Local Run with Docker
+
+After creating the `.env` file, start the project with:
+
+```bash
+docker compose up --build


### PR DESCRIPTION
## Summary

* added and cleaned up the root `.env.example`
* documented required environment variables in `README.md`
* ensured local `.env` files are ignored by git
* clarified local configuration for Docker-based setup

## Changes made

* added environment variable placeholders for database, JWT, API, and Docker configuration
* included `BACKEND_URL` and `VITE_API_URL` for clearer local setup documentation
* documented each environment variable and how to run the project locally with Docker

## Validation

* confirmed `.env` is ignored via `.gitignore`
* local app configuration now relies on the documented environment variables

Fixes #71
