### PR TITLE
test(infra): smoke test Docker setup and deployment Fixes #67

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -39,6 +39,29 @@ jobs:
         with:
           dotnet-version: 9.0.x
 
+      - name: Start SQL Server
+        run: |
+          docker run -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=TestPassword123!" \
+            -p 1433:1433 --name mssql \
+            -d mcr.microsoft.com/mssql/server:2022-latest
+          echo "Waiting for SQL Server..."
+          timeout 60 bash -c 'until docker exec mssql /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P TestPassword123! -Q "SELECT 1" -No 2>/dev/null; do sleep 3; done'
+          echo "SQL Server ready"
+
+      - name: Start backend API
+        env:
+          ConnectionStrings__DefaultConnection: "Server=localhost,1433;Database=TaskMateDb;User Id=sa;Password=TestPassword123!;TrustServerCertificate=True;Encrypt=False;"
+          Jwt__Key: "ThisIsASecretKeyForTaskMateJwt123!"
+          Jwt__Issuer: "TaskMate.API"
+          Jwt__Audience: "TaskMate.Client"
+          Jwt__ExpiresInHours: "24"
+          ASPNETCORE_URLS: "http://+:5048"
+        run: |
+          dotnet run --project backend/TaskMate.API --no-launch-profile &
+          echo "Waiting for API..."
+          timeout 60 bash -c 'until curl -sf http://localhost:5048/swagger/index.html; do sleep 2; done'
+          echo "API ready"
+
       - run: dotnet restore backend/TaskMate.Tests
 
       - run: dotnet test backend/TaskMate.Tests

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -56,6 +56,7 @@ jobs:
           Jwt__Audience: "TaskMate.Client"
           Jwt__ExpiresInHours: "24"
           ASPNETCORE_URLS: "http://+:5048"
+          ASPNETCORE_ENVIRONMENT: "Development"
         run: |
           dotnet run --project backend/TaskMate.API --no-launch-profile &
           echo "Waiting for API..."

--- a/backend/TaskMate.Tests/Helpers/ApiClient.cs
+++ b/backend/TaskMate.Tests/Helpers/ApiClient.cs
@@ -1,0 +1,62 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+
+namespace TaskMate.Tests.Helpers;
+
+public class ApiClient
+{
+    private readonly HttpClient _client;
+
+    private static readonly string BaseUrl =
+        Environment.GetEnvironmentVariable("API_BASE_URL") ?? "http://localhost:5048";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    public ApiClient()
+    {
+        _client = new HttpClient { BaseAddress = new Uri(BaseUrl) };
+    }
+
+    public void SetToken(string token)
+    {
+        _client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", token);
+    }
+
+    public async Task<HttpResponseMessage> PostAsync(string url, object body)
+    {
+        var json = JsonSerializer.Serialize(body);
+        var content = new StringContent(json, Encoding.UTF8, "application/json");
+        return await _client.PostAsync(url, content);
+    }
+
+    public async Task<HttpResponseMessage> GetAsync(string url)
+        => await _client.GetAsync(url);
+
+    public async Task<HttpResponseMessage> PutAsync(string url, object body)
+    {
+        var json = JsonSerializer.Serialize(body);
+        var content = new StringContent(json, Encoding.UTF8, "application/json");
+        return await _client.PutAsync(url, content);
+    }
+
+    public async Task<HttpResponseMessage> PatchAsync(string url, object body)
+    {
+        var json = JsonSerializer.Serialize(body);
+        var content = new StringContent(json, Encoding.UTF8, "application/json");
+        return await _client.PatchAsync(url, content);
+    }
+
+    public async Task<HttpResponseMessage> DeleteAsync(string url)
+        => await _client.DeleteAsync(url);
+
+    public static async Task<T?> DeserializeAsync<T>(HttpResponseMessage response)
+    {
+        var content = await response.Content.ReadAsStringAsync();
+        return JsonSerializer.Deserialize<T>(content, JsonOptions);
+    }
+}

--- a/backend/TaskMate.Tests/SmokeTests.cs
+++ b/backend/TaskMate.Tests/SmokeTests.cs
@@ -1,0 +1,40 @@
+using System.Net;
+using TaskMate.Tests.Helpers;
+
+namespace TaskMate.Tests;
+
+/// <summary>
+/// TC-INFRA: Smoke tests — verifică că infrastructura Docker e funcțională (#67)
+/// </summary>
+public class SmokeTests
+{
+    // TC-INFRA-01: API pornit — Swagger returnează 200
+    [Fact]
+    public async Task Api_IsRunning_SwaggerReturns200()
+    {
+        var client = new ApiClient();
+        var response = await client.GetAsync("/swagger/index.html");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    // TC-INFRA-02: Endpoint-ul de auth e accesibil (nu returnează 500)
+    [Fact]
+    public async Task Api_AuthEndpoint_IsReachable()
+    {
+        var client = new ApiClient();
+        var response = await client.PostAsync("/api/auth/login", new { });
+
+        Assert.NotEqual(HttpStatusCode.InternalServerError, response.StatusCode);
+    }
+
+    // TC-INFRA-03: Endpoint-ul de tasks necesită autentificare (returnează 401, nu 500)
+    [Fact]
+    public async Task Api_TasksEndpoint_RequiresAuth_Returns401()
+    {
+        var client = new ApiClient();
+        var response = await client.GetAsync("/api/tasks");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+}

--- a/backend/TaskMate.Tests/TaskMate.Tests.csproj
+++ b/backend/TaskMate.Tests/TaskMate.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
## User Story
As a QA engineer, I want automated smoke tests for the Docker infrastructure, 
so that I can verify the API is running correctly after each deployment.

## Acceptance Criteria
- API is reachable and Swagger returns 200
- Auth endpoint responds (does not return 500)
- Tasks endpoint requires authentication (returns 401)

## Changes
- Added `SmokeTests.cs` with 3 automated integration tests
- Added `Helpers/ApiClient.cs` for HTTP requests in tests
- Fixed test project target framework (net10.0 → net9.0)

Closes #67