### PR TITLE
feat(tasks): add estimatedMinutes support and stats endpoint Fixes #50

### DIFF
--- a/backend/TaskMate.API/Controllers/TasksController.cs
+++ b/backend/TaskMate.API/Controllers/TasksController.cs
@@ -44,12 +44,19 @@ namespace TaskMate.API.Controllers
                 return BadRequest("Title is required");
             }
 
+            if (dto.EstimatedMinutes.HasValue && dto.EstimatedMinutes.Value < 0)
+            {
+                _logger.LogWarning("Create task failed because estimatedMinutes is negative for user {UserId}", userId);
+                return BadRequest("EstimatedMinutes must be greater than or equal to 0");
+            }
+
             var task = new TaskItem
             {
                 Title = dto.Title,
                 Description = dto.Description,
                 Deadline = dto.Deadline,
                 Priority = dto.Priority,
+                EstimatedMinutes = dto.EstimatedMinutes,
                 SubjectId = dto.SubjectId,
                 UserId = GetUserId(),
                 Status = TaskStatus.Todo
@@ -78,6 +85,40 @@ namespace TaskMate.API.Controllers
             _logger.LogInformation("Fetched {Count} tasks for user {UserId}", tasks.Count, userId);
 
             return Ok(tasks);
+        }
+
+        [HttpGet("stats")]
+        [Authorize]
+        public async Task<IActionResult> GetStats()
+        {
+            var userId = GetUserId();
+            var now = DateTime.UtcNow;
+            var startOfToday = now.Date;
+            var endOfToday = startOfToday.AddDays(1);
+            var startOfWeek = startOfToday.AddDays(-((int)startOfToday.DayOfWeek + 6) % 7);
+            var endOfWeek = startOfWeek.AddDays(7);
+
+            _logger.LogInformation("Fetching task stats for user {UserId}", userId);
+
+            var totalEstimatedMinutesToday = await _context.Tasks
+                .Where(t => t.UserId == userId
+                            && t.Deadline.HasValue
+                            && t.Deadline.Value >= startOfToday
+                            && t.Deadline.Value < endOfToday)
+                .SumAsync(t => t.EstimatedMinutes ?? 0);
+
+            var totalEstimatedMinutesWeek = await _context.Tasks
+                .Where(t => t.UserId == userId
+                            && t.Deadline.HasValue
+                            && t.Deadline.Value >= startOfWeek
+                            && t.Deadline.Value < endOfWeek)
+                .SumAsync(t => t.EstimatedMinutes ?? 0);
+
+            return Ok(new
+            {
+                totalEstimatedMinutesToday,
+                totalEstimatedMinutesWeek
+            });
         }
 
         [HttpGet("{id}")]
@@ -123,11 +164,18 @@ namespace TaskMate.API.Controllers
                 return BadRequest("Title is required");
             }
 
+            if (dto.EstimatedMinutes.HasValue && dto.EstimatedMinutes.Value < 0)
+            {
+                _logger.LogWarning("Update task failed because estimatedMinutes is negative. TaskId: {TaskId}, UserId: {UserId}", id, userId);
+                return BadRequest("EstimatedMinutes must be greater than or equal to 0");
+            }
+
             task.Title = dto.Title;
             task.Description = dto.Description;
             task.Deadline = dto.Deadline;
             task.Priority = dto.Priority;
             task.Status = dto.Status;
+            task.EstimatedMinutes = dto.EstimatedMinutes;
             task.SubjectId = dto.SubjectId;
             task.UpdatedAt = DateTime.UtcNow;
 

--- a/backend/TaskMate.API/Models/DTOs/CreateTaskDto.cs
+++ b/backend/TaskMate.API/Models/DTOs/CreateTaskDto.cs
@@ -12,6 +12,7 @@ public class CreateTaskDto
     public string? Description { get; set; }
     public DateTime? Deadline { get; set; }
     public TaskPriority Priority { get; set; }
+    public int? EstimatedMinutes { get; set; }
     public Guid? SubjectId { get; set; }
 }
 }

--- a/backend/TaskMate.API/Models/DTOs/UpdateTaskDto.cs
+++ b/backend/TaskMate.API/Models/DTOs/UpdateTaskDto.cs
@@ -15,6 +15,7 @@ public class UpdateTaskDto
     public DateTime? Deadline { get; set; }
     public TaskPriority Priority { get; set; }
     public TaskStatus Status { get; set; }
+    public int? EstimatedMinutes { get; set; }
     public Guid? SubjectId { get; set; }
 }
 }

--- a/backend/TaskMate.Tests/TasksTests.cs
+++ b/backend/TaskMate.Tests/TasksTests.cs
@@ -45,6 +45,26 @@ public class TasksTests
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
     }
 
+    [Fact]
+    public async Task CreateTask_WithEstimatedMinutes_PersistsValue()
+    {
+        var client = await CreateAuthenticatedClient();
+
+        var response = await client.PostAsync("/api/tasks", new
+        {
+            title = "Task with estimate",
+            priority = 1,
+            estimatedMinutes = 45
+        });
+
+        var createdTask = await ApiClient.DeserializeAsync<Dictionary<string, JsonElement>>(response);
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        Assert.NotNull(createdTask);
+        Assert.True(createdTask!.ContainsKey("estimatedMinutes"));
+        Assert.Equal(45, createdTask["estimatedMinutes"].GetInt32());
+    }
+
     // TC-TASK-02: Creare task fără titlu → 400
     [Fact]
     public async Task CreateTask_WithoutTitle_Returns400()
@@ -127,6 +147,31 @@ public class TasksTests
         Assert.Equal(HttpStatusCode.OK, updateResponse.StatusCode);
     }
 
+    [Fact]
+    public async Task UpdateTask_WithEstimatedMinutes_UpdatesValue()
+    {
+        var client = await CreateAuthenticatedClient();
+
+        var createResponse = await client.PostAsync("/api/tasks", new { title = "Original Title", priority = 0 });
+        var createdTask = await ApiClient.DeserializeAsync<Dictionary<string, JsonElement>>(createResponse);
+        var taskId = createdTask!["id"].GetString();
+
+        var updateResponse = await client.PutAsync($"/api/tasks/{taskId}", new
+        {
+            title = "Updated Title",
+            priority = 2,
+            status = 1,
+            estimatedMinutes = 120
+        });
+
+        var updatedTask = await ApiClient.DeserializeAsync<Dictionary<string, JsonElement>>(updateResponse);
+
+        Assert.Equal(HttpStatusCode.OK, updateResponse.StatusCode);
+        Assert.NotNull(updatedTask);
+        Assert.True(updatedTask!.ContainsKey("estimatedMinutes"));
+        Assert.Equal(120, updatedTask["estimatedMinutes"].GetInt32());
+    }
+
     // TC-TASK-07: Editare task inexistent → 404
     [Fact]
     public async Task UpdateTask_NonExisting_Returns404()
@@ -201,5 +246,49 @@ public class TasksTests
         var patchResponse = await client.PatchAsync($"/api/tasks/{taskId}", new { status = 2 }); // Done
 
         Assert.Equal(HttpStatusCode.OK, patchResponse.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetTaskStats_ReturnsEstimatedMinutesTodayAndWeek()
+    {
+        var client = await CreateAuthenticatedClient();
+
+        var todayDeadline = DateTime.UtcNow.AddHours(2);
+        var weekDeadline = DateTime.UtcNow.Date.AddDays(2).AddHours(1);
+        var outsideWeekDeadline = DateTime.UtcNow.Date.AddDays(10);
+
+        await client.PostAsync("/api/tasks", new
+        {
+            title = "Today Task",
+            priority = 1,
+            deadline = todayDeadline,
+            estimatedMinutes = 30
+        });
+
+        await client.PostAsync("/api/tasks", new
+        {
+            title = "Week Task",
+            priority = 1,
+            deadline = weekDeadline,
+            estimatedMinutes = 90
+        });
+
+        await client.PostAsync("/api/tasks", new
+        {
+            title = "Outside Week Task",
+            priority = 1,
+            deadline = outsideWeekDeadline,
+            estimatedMinutes = 300
+        });
+
+        var statsResponse = await client.GetAsync("/api/tasks/stats");
+        var stats = await ApiClient.DeserializeAsync<Dictionary<string, JsonElement>>(statsResponse);
+
+        Assert.Equal(HttpStatusCode.OK, statsResponse.StatusCode);
+        Assert.NotNull(stats);
+        Assert.True(stats!.ContainsKey("totalEstimatedMinutesToday"));
+        Assert.True(stats.ContainsKey("totalEstimatedMinutesWeek"));
+        Assert.Equal(30, stats["totalEstimatedMinutesToday"].GetInt32());
+        Assert.Equal(120, stats["totalEstimatedMinutesWeek"].GetInt32());
     }
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -63,7 +63,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -290,7 +289,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -334,7 +332,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
@@ -347,7 +344,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -976,7 +972,6 @@
       "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -987,7 +982,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1047,7 +1041,6 @@
       "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.2",
         "@typescript-eslint/types": "8.58.2",
@@ -1330,7 +1323,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1439,7 +1431,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -1642,7 +1633,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2599,7 +2589,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2641,6 +2630,7 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.12.1.tgz",
       "integrity": "sha512-l8386ixSsBdbreOAkqtrwqHwdvR35ID8c3rKPa8lCWuO86dBi32QWHV4vfsZK1utLLFMvw+Z5Ad4XLkZzchscg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -2671,7 +2661,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2681,7 +2670,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -2914,7 +2902,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3001,7 +2988,6 @@
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -3126,7 +3112,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
Include estimatedMinutes in task create/update flows and expose today/week estimated minute totals in tasks stats for planning visibility.