### PR TITLE
feat(tasks): add isOverdue and isDueToday to GET /api/tasks

### DIFF
--- a/backend/TaskMate.API/Controllers/TasksController.cs
+++ b/backend/TaskMate.API/Controllers/TasksController.cs
@@ -82,9 +82,12 @@ namespace TaskMate.API.Controllers
                 .Where(t => t.UserId == userId)
                 .ToListAsync();
 
-            _logger.LogInformation("Fetched {Count} tasks for user {UserId}", tasks.Count, userId);
+            var utcNow = DateTime.UtcNow;
+            var response = tasks.Select(t => TaskItemResponse.From(t, utcNow)).ToList();
 
-            return Ok(tasks);
+            _logger.LogInformation("Fetched {Count} tasks for user {UserId}", response.Count, userId);
+
+            return Ok(response);
         }
 
         [HttpGet("stats")]

--- a/backend/TaskMate.API/Models/DTOs/TaskItemResponse.cs
+++ b/backend/TaskMate.API/Models/DTOs/TaskItemResponse.cs
@@ -1,0 +1,67 @@
+using TaskMate.API.Models.Entities;
+using TaskMate.API.Models.Enums;
+
+namespace TaskMate.API.Models.DTOs;
+
+public class TaskItemResponse
+{
+    public Guid Id { get; set; }
+    public string Title { get; set; } = null!;
+    public string? Description { get; set; }
+    public DateTime? Deadline { get; set; }
+    public TaskMate.API.Models.Enums.TaskStatus Status { get; set; }
+    public TaskPriority Priority { get; set; }
+    public int? EstimatedMinutes { get; set; }
+    public bool IsPinned { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+    public Guid UserId { get; set; }
+    public Guid? SubjectId { get; set; }
+    public bool IsOverdue { get; set; }
+    public bool IsDueToday { get; set; }
+
+    public static TaskItemResponse From(TaskItem task, DateTime utcNow)
+    {
+        var todayUtc = utcNow.Date;
+        var isDone = task.Status == TaskMate.API.Models.Enums.TaskStatus.Done;
+
+        var isOverdue = false;
+        var isDueToday = false;
+
+        if (task.Deadline.HasValue && !isDone)
+        {
+            var deadlineDate = ToUtcDate(task.Deadline.Value);
+            isOverdue = deadlineDate < todayUtc;
+            isDueToday = deadlineDate == todayUtc;
+        }
+
+        return new TaskItemResponse
+        {
+            Id = task.Id,
+            Title = task.Title,
+            Description = task.Description,
+            Deadline = task.Deadline,
+            Status = task.Status,
+            Priority = task.Priority,
+            EstimatedMinutes = task.EstimatedMinutes,
+            IsPinned = task.IsPinned,
+            CreatedAt = task.CreatedAt,
+            UpdatedAt = task.UpdatedAt,
+            UserId = task.UserId,
+            SubjectId = task.SubjectId,
+            IsOverdue = isOverdue,
+            IsDueToday = isDueToday
+        };
+    }
+
+    private static DateTime ToUtcDate(DateTime value)
+    {
+        var utc = value.Kind switch
+        {
+            DateTimeKind.Utc => value,
+            DateTimeKind.Local => value.ToUniversalTime(),
+            _ => DateTime.SpecifyKind(value, DateTimeKind.Utc)
+        };
+        return utc.Date;
+    }
+}


### PR DESCRIPTION
Return TaskItemResponse with server-side UTC date checks: overdue when deadline date is before today and status is not Done; due today when deadline date matches today UTC and status is not Done. Fixes #35.
