### PR TITLE
test(subjects,progress): write and execute test cases for subjects an…

### DIFF
--- a/backend/TaskMate.Tests/SubjectsTests.cs
+++ b/backend/TaskMate.Tests/SubjectsTests.cs
@@ -1,0 +1,134 @@
+using System.Net;
+using System.Text.Json;
+using TaskMate.Tests.Helpers;
+
+namespace TaskMate.Tests;
+
+/// <summary>
+/// TC-SUBJECT: Teste de integrare pentru gestionarea subiectelor (#66)
+/// Acoperă: creare, listare, editare, ștergere subjects
+/// </summary>
+public class SubjectsTests
+{
+    private async Task<ApiClient> CreateAuthenticatedClient()
+    {
+        var client = new ApiClient();
+        var email = $"test_{Guid.NewGuid()}@taskmate.test";
+
+        var registerResponse = await client.PostAsync("/api/auth/register", new
+        {
+            email,
+            password = "Password123!"
+        });
+
+        var body = await ApiClient.DeserializeAsync<Dictionary<string, string>>(registerResponse);
+        client.SetToken(body!["token"]);
+
+        return client;
+    }
+
+    // ─── CREATE ───────────────────────────────────────────────────────────────
+
+    // TC-SUBJECT-01: Creare subject cu date valide → 201
+    [Fact]
+    public async Task CreateSubject_WithValidData_Returns201()
+    {
+        var client = await CreateAuthenticatedClient();
+
+        var response = await client.PostAsync("/api/subjects", new
+        {
+            name = "Mathematics",
+            color = "#FF5733"
+        });
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+    }
+
+    // TC-SUBJECT-02: Creare subject fără nume → 400
+    [Fact]
+    public async Task CreateSubject_WithoutName_Returns400()
+    {
+        var client = await CreateAuthenticatedClient();
+
+        var response = await client.PostAsync("/api/subjects", new
+        {
+            name = "",
+            color = "#FF5733"
+        });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    // TC-SUBJECT-03: Creare subject fără autentificare → 401
+    [Fact]
+    public async Task CreateSubject_WithoutAuth_Returns401()
+    {
+        var client = new ApiClient();
+
+        var response = await client.PostAsync("/api/subjects", new
+        {
+            name = "Math",
+            color = "#FF5733"
+        });
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    // ─── READ ─────────────────────────────────────────────────────────────────
+
+    // TC-SUBJECT-04: Listare subjects autentificat → 200
+    [Fact]
+    public async Task GetSubjects_Authenticated_Returns200()
+    {
+        var client = await CreateAuthenticatedClient();
+
+        var response = await client.GetAsync("/api/subjects");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    // TC-SUBJECT-05: Un user nu vede subjects-urile altui user
+    [Fact]
+    public async Task GetSubjects_DoesNotReturnOtherUsersSubjects()
+    {
+        var client1 = await CreateAuthenticatedClient();
+        var client2 = await CreateAuthenticatedClient();
+
+        await client1.PostAsync("/api/subjects", new { name = "User1 Private Subject", color = "#000" });
+
+        var response = await client2.GetAsync("/api/subjects");
+        var subjects = await ApiClient.DeserializeAsync<List<Dictionary<string, JsonElement>>>(response);
+
+        Assert.NotNull(subjects);
+        Assert.DoesNotContain(subjects, s =>
+            s.ContainsKey("name") && s["name"].GetString() == "User1 Private Subject");
+    }
+
+    // ─── DELETE ───────────────────────────────────────────────────────────────
+
+    // TC-SUBJECT-08: Ștergere subject existent → 204
+    [Fact]
+    public async Task DeleteSubject_Existing_Returns204()
+    {
+        var client = await CreateAuthenticatedClient();
+
+        var createResponse = await client.PostAsync("/api/subjects", new { name = "To Delete", color = "#000" });
+        var subject = await ApiClient.DeserializeAsync<Dictionary<string, JsonElement>>(createResponse);
+        var subjectId = subject!["id"].GetString();
+
+        var deleteResponse = await client.DeleteAsync($"/api/subjects/{subjectId}");
+
+        Assert.Equal(HttpStatusCode.NoContent, deleteResponse.StatusCode);
+    }
+
+    // TC-SUBJECT-09: Ștergere subject inexistent → 404
+    [Fact]
+    public async Task DeleteSubject_NonExisting_Returns404()
+    {
+        var client = await CreateAuthenticatedClient();
+
+        var response = await client.DeleteAsync($"/api/subjects/{Guid.NewGuid()}");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+}


### PR DESCRIPTION
## User Story
As a QA engineer, I want automated tests for subject management,
so that I can verify CRUD operations for subjects work correctly.

## Acceptance Criteria
- Create subject with valid data returns 201
- Create subject without name returns 400
- Create subject without authentication returns 401
- Get subjects returns 200
- User cannot see other users' subjects
- Delete existing subject returns 204
- Delete non-existing subject returns 404

## Changes
- Added `SubjectsTests.cs` with 7 automated integration tests

## Known Issues
- `PUT /api/subjects/{id}` always returns 400 due to API bug (reported separately)

Closes #66