### PR TITLE
chore(tests): translate Romanian comments to English

### DIFF
--- a/backend/TaskMate.Tests/AuthTests.cs
+++ b/backend/TaskMate.Tests/AuthTests.cs
@@ -4,12 +4,12 @@ using TaskMate.Tests.Helpers;
 namespace TaskMate.Tests;
 
 /// <summary>
-/// TC-AUTH: Teste de integrare pentru autentificare (#61)
-/// Acoperă: register, login, validări de input
+/// TC-AUTH: Integration tests for authentication (#61)
+/// Covers: register, login, input validation
 /// </summary>
 public class AuthTests
 {
-    // TC-AUTH-01: Register cu date valide → 201 + token JWT
+    // TC-AUTH-01: Register with valid data → 201 + JWT token
     [Fact]
     public async Task Register_WithValidCredentials_Returns201AndToken()
     {
@@ -30,7 +30,7 @@ public class AuthTests
         Assert.False(string.IsNullOrEmpty(body["token"]));
     }
 
-    // TC-AUTH-02: Register cu email duplicat → 400
+    // TC-AUTH-02: Register with duplicate email → 400
     [Fact]
     public async Task Register_WithDuplicateEmail_Returns400()
     {
@@ -43,7 +43,7 @@ public class AuthTests
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
-    // TC-AUTH-03: Register cu parolă mai scurtă de 8 caractere → 400
+    // TC-AUTH-03: Register with password shorter than 8 characters → 400
     [Fact]
     public async Task Register_WithShortPassword_Returns400()
     {
@@ -58,7 +58,7 @@ public class AuthTests
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
-    // TC-AUTH-04: Register cu format invalid de email → 400
+    // TC-AUTH-04: Register with invalid email format → 400
     [Fact]
     public async Task Register_WithInvalidEmailFormat_Returns400()
     {
@@ -73,7 +73,7 @@ public class AuthTests
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
-    // TC-AUTH-05: Login cu credențiale valide → 200 + token JWT
+    // TC-AUTH-05: Login with valid credentials → 200 + JWT token
     [Fact]
     public async Task Login_WithValidCredentials_Returns200AndToken()
     {
@@ -92,7 +92,7 @@ public class AuthTests
         Assert.False(string.IsNullOrEmpty(body["token"]));
     }
 
-    // TC-AUTH-06: Login cu parolă greșită → 401
+    // TC-AUTH-06: Login with wrong password → 401
     [Fact]
     public async Task Login_WithWrongPassword_Returns401()
     {
@@ -105,7 +105,7 @@ public class AuthTests
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
 
-    // TC-AUTH-07: Login cu email inexistent → 401
+    // TC-AUTH-07: Login with non-existent email → 401
     [Fact]
     public async Task Login_WithNonExistentEmail_Returns401()
     {

--- a/backend/TaskMate.Tests/SubjectsTests.cs
+++ b/backend/TaskMate.Tests/SubjectsTests.cs
@@ -5,8 +5,8 @@ using TaskMate.Tests.Helpers;
 namespace TaskMate.Tests;
 
 /// <summary>
-/// TC-SUBJECT: Teste de integrare pentru gestionarea subiectelor (#66)
-/// Acoperă: creare, listare, editare, ștergere subjects
+/// TC-SUBJECT: Integration tests for subject management (#66)
+/// Covers: create, list, edit, delete subjects
 /// </summary>
 public class SubjectsTests
 {
@@ -29,7 +29,7 @@ public class SubjectsTests
 
     // ─── CREATE ───────────────────────────────────────────────────────────────
 
-    // TC-SUBJECT-01: Creare subject cu date valide → 201
+    // TC-SUBJECT-01: Create subject with valid data → 201
     [Fact]
     public async Task CreateSubject_WithValidData_Returns201()
     {
@@ -44,7 +44,7 @@ public class SubjectsTests
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
     }
 
-    // TC-SUBJECT-02: Creare subject fără nume → 400
+    // TC-SUBJECT-02: Create subject without name → 400
     [Fact]
     public async Task CreateSubject_WithoutName_Returns400()
     {
@@ -59,7 +59,7 @@ public class SubjectsTests
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
-    // TC-SUBJECT-03: Creare subject fără autentificare → 401
+    // TC-SUBJECT-03: Create subject without authentication → 401
     [Fact]
     public async Task CreateSubject_WithoutAuth_Returns401()
     {
@@ -76,7 +76,7 @@ public class SubjectsTests
 
     // ─── READ ─────────────────────────────────────────────────────────────────
 
-    // TC-SUBJECT-04: Listare subjects autentificat → 200
+    // TC-SUBJECT-04: List subjects authenticated → 200
     [Fact]
     public async Task GetSubjects_Authenticated_Returns200()
     {
@@ -87,7 +87,7 @@ public class SubjectsTests
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
-    // TC-SUBJECT-05: Un user nu vede subjects-urile altui user
+    // TC-SUBJECT-05: A user does not see another user's subjects
     [Fact]
     public async Task GetSubjects_DoesNotReturnOtherUsersSubjects()
     {
@@ -106,7 +106,7 @@ public class SubjectsTests
 
     // ─── DELETE ───────────────────────────────────────────────────────────────
 
-    // TC-SUBJECT-08: Ștergere subject existent → 204
+    // TC-SUBJECT-08: Delete existing subject → 204
     [Fact]
     public async Task DeleteSubject_Existing_Returns204()
     {
@@ -121,7 +121,7 @@ public class SubjectsTests
         Assert.Equal(HttpStatusCode.NoContent, deleteResponse.StatusCode);
     }
 
-    // TC-SUBJECT-09: Ștergere subject inexistent → 404
+    // TC-SUBJECT-09: Delete non-existing subject → 404
     [Fact]
     public async Task DeleteSubject_NonExisting_Returns404()
     {

--- a/backend/TaskMate.Tests/TasksFilterSortTests.cs
+++ b/backend/TaskMate.Tests/TasksFilterSortTests.cs
@@ -5,8 +5,8 @@ using TaskMate.Tests.Helpers;
 namespace TaskMate.Tests;
 
 /// <summary>
-/// TC-FILTER: Teste de integrare pentru filtrare și sortare task-uri (#64)
-/// Acoperă: filter status/priority, sort deadline/priority, validări parametri invalizi
+/// TC-FILTER: Integration tests for task filtering and sorting (#64)
+/// Covers: filter by status/priority, sort by deadline/priority, invalid parameter validation
 /// </summary>
 public class TasksFilterSortTests
 {
@@ -29,7 +29,7 @@ public class TasksFilterSortTests
 
     // ─── FILTER STATUS ────────────────────────────────────────────────────────
 
-    // TC-FILTER-01: Filter după status=Todo → returnează doar task-urile Todo
+    // TC-FILTER-01: Filter by status=Todo → returns only Todo tasks
     [Fact]
     public async Task GetTasks_FilterByStatus_ReturnsOnlyMatchingTasks()
     {
@@ -49,7 +49,7 @@ public class TasksFilterSortTests
         Assert.All(tasks, t => Assert.Equal(0, t["status"].GetInt32())); // 0 = Todo
     }
 
-    // TC-FILTER-02: Filter după status invalid → 400
+    // TC-FILTER-02: Filter by invalid status → 400
     [Fact]
     public async Task GetTasks_FilterByInvalidStatus_Returns400()
     {
@@ -62,7 +62,7 @@ public class TasksFilterSortTests
 
     // ─── FILTER PRIORITY ──────────────────────────────────────────────────────
 
-    // TC-FILTER-03: Filter după priority=High → returnează doar task-urile High
+    // TC-FILTER-03: Filter by priority=High → returns only High priority tasks
     [Fact]
     public async Task GetTasks_FilterByPriority_ReturnsOnlyMatchingTasks()
     {
@@ -79,7 +79,7 @@ public class TasksFilterSortTests
         Assert.All(tasks, t => Assert.Equal(2, t["priority"].GetInt32())); // 2 = High
     }
 
-    // TC-FILTER-04: Filter după priority invalid → 400
+    // TC-FILTER-04: Filter by invalid priority → 400
     [Fact]
     public async Task GetTasks_FilterByInvalidPriority_Returns400()
     {
@@ -92,7 +92,7 @@ public class TasksFilterSortTests
 
     // ─── SORT ─────────────────────────────────────────────────────────────────
 
-    // TC-FILTER-05: Sortare după priority desc → 200
+    // TC-FILTER-05: Sort by priority desc → 200
     [Fact]
     public async Task GetTasks_SortByPriorityDesc_Returns200()
     {
@@ -106,7 +106,7 @@ public class TasksFilterSortTests
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
-    // TC-FILTER-06: Sortare după deadline asc → 200
+    // TC-FILTER-06: Sort by deadline asc → 200
     [Fact]
     public async Task GetTasks_SortByDeadlineAsc_Returns200()
     {
@@ -120,7 +120,7 @@ public class TasksFilterSortTests
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
-    // TC-FILTER-07: sortBy invalid → 400
+    // TC-FILTER-07: Invalid sortBy → 400
     [Fact]
     public async Task GetTasks_InvalidSortBy_Returns400()
     {
@@ -131,7 +131,7 @@ public class TasksFilterSortTests
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
-    // TC-FILTER-08: order fără sortBy → 400
+    // TC-FILTER-08: order without sortBy → 400
     [Fact]
     public async Task GetTasks_OrderWithoutSortBy_Returns400()
     {
@@ -142,7 +142,7 @@ public class TasksFilterSortTests
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
-    // TC-FILTER-09: order invalid → 400
+    // TC-FILTER-09: Invalid order → 400
     [Fact]
     public async Task GetTasks_InvalidOrder_Returns400()
     {

--- a/backend/TaskMate.Tests/TasksOverdueTests.cs
+++ b/backend/TaskMate.Tests/TasksOverdueTests.cs
@@ -5,8 +5,8 @@ using TaskMate.Tests.Helpers;
 namespace TaskMate.Tests;
 
 /// <summary>
-/// TC-OVERDUE: Teste de integrare pentru deadline highlighting (#65)
-/// Acoperă: isOverdue, isDueToday pe task-uri returnate de GET /api/tasks
+/// TC-OVERDUE: Integration tests for deadline highlighting (#65)
+/// Covers: isOverdue, isDueToday on tasks returned by GET /api/tasks
 /// </summary>
 public class TasksOverdueTests
 {
@@ -34,7 +34,7 @@ public class TasksOverdueTests
         return tasks?.FirstOrDefault(t => t["id"].GetString() == taskId);
     }
 
-    // TC-OVERDUE-01: Task cu deadline în trecut → isOverdue = true
+    // TC-OVERDUE-01: Task with past deadline → isOverdue = true
     [Fact]
     public async Task GetTasks_TaskWithPastDeadline_IsOverdueTrue()
     {
@@ -56,7 +56,7 @@ public class TasksOverdueTests
         Assert.False(task["isDueToday"].GetBoolean());
     }
 
-    // TC-OVERDUE-02: Task cu deadline azi → isDueToday = true
+    // TC-OVERDUE-02: Task with today's deadline → isDueToday = true
     [Fact]
     public async Task GetTasks_TaskWithTodayDeadline_IsDueTodayTrue()
     {
@@ -78,7 +78,7 @@ public class TasksOverdueTests
         Assert.False(task["isOverdue"].GetBoolean());
     }
 
-    // TC-OVERDUE-03: Task cu deadline în viitor → isOverdue = false, isDueToday = false
+    // TC-OVERDUE-03: Task with future deadline → isOverdue = false, isDueToday = false
     [Fact]
     public async Task GetTasks_TaskWithFutureDeadline_BothFalse()
     {
@@ -100,7 +100,7 @@ public class TasksOverdueTests
         Assert.False(task["isDueToday"].GetBoolean());
     }
 
-    // TC-OVERDUE-04: Task fără deadline → isOverdue = false, isDueToday = false
+    // TC-OVERDUE-04: Task without deadline → isOverdue = false, isDueToday = false
     [Fact]
     public async Task GetTasks_TaskWithoutDeadline_BothFalse()
     {
@@ -120,7 +120,7 @@ public class TasksOverdueTests
         Assert.False(task["isDueToday"].GetBoolean());
     }
 
-    // TC-OVERDUE-05: Task Done cu deadline în trecut → isOverdue = false
+    // TC-OVERDUE-05: Done task with past deadline → isOverdue = false
     [Fact]
     public async Task GetTasks_DoneTaskWithPastDeadline_IsOverdueFalse()
     {

--- a/backend/TaskMate.Tests/TasksTests.cs
+++ b/backend/TaskMate.Tests/TasksTests.cs
@@ -5,8 +5,8 @@ using TaskMate.Tests.Helpers;
 namespace TaskMate.Tests;
 
 /// <summary>
-/// TC-TASK: Teste de integrare pentru gestionarea task-urilor (#62, #63)
-/// Acoperă: creare, citire, editare, ștergere, schimbare status (Kanban)
+/// TC-TASK: Integration tests for task management (#62, #63)
+/// Covers: create, read, update, delete, status change (Kanban)
 /// </summary>
 public class TasksTests
 {
@@ -29,7 +29,7 @@ public class TasksTests
 
     // ─── CREATE ───────────────────────────────────────────────────────────────
 
-    // TC-TASK-01: Creare task cu date valide → 201
+    // TC-TASK-01: Create task with valid data → 201
     [Fact]
     public async Task CreateTask_WithValidData_Returns201()
     {
@@ -65,7 +65,7 @@ public class TasksTests
         Assert.Equal(45, createdTask["estimatedMinutes"].GetInt32());
     }
 
-    // TC-TASK-02: Creare task fără titlu → 400
+    // TC-TASK-02: Create task without title → 400
     [Fact]
     public async Task CreateTask_WithoutTitle_Returns400()
     {
@@ -80,7 +80,7 @@ public class TasksTests
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
-    // TC-TASK-03: Creare task fără autentificare → 401
+    // TC-TASK-03: Create task without authentication → 401
     [Fact]
     public async Task CreateTask_WithoutAuth_Returns401()
     {
@@ -97,7 +97,7 @@ public class TasksTests
 
     // ─── READ ─────────────────────────────────────────────────────────────────
 
-    // TC-TASK-04: Listare task-uri autentificat → 200
+    // TC-TASK-04: List tasks authenticated → 200
     [Fact]
     public async Task GetAllTasks_Authenticated_Returns200()
     {
@@ -108,7 +108,7 @@ public class TasksTests
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
-    // TC-TASK-05: Un user nu vede task-urile altui user
+    // TC-TASK-05: A user does not see another user's tasks
     [Fact]
     public async Task GetAllTasks_DoesNotReturnOtherUsersTasks()
     {
@@ -127,7 +127,7 @@ public class TasksTests
 
     // ─── UPDATE ───────────────────────────────────────────────────────────────
 
-    // TC-TASK-06: Editare task cu date valide → 200
+    // TC-TASK-06: Update task with valid data → 200
     [Fact]
     public async Task UpdateTask_WithValidData_Returns200()
     {
@@ -172,7 +172,7 @@ public class TasksTests
         Assert.Equal(120, updatedTask["estimatedMinutes"].GetInt32());
     }
 
-    // TC-TASK-07: Editare task inexistent → 404
+    // TC-TASK-07: Update non-existing task → 404
     [Fact]
     public async Task UpdateTask_NonExisting_Returns404()
     {
@@ -190,7 +190,7 @@ public class TasksTests
 
     // ─── DELETE ───────────────────────────────────────────────────────────────
 
-    // TC-TASK-08: Ștergere task existent → 204
+    // TC-TASK-08: Delete existing task → 204
     [Fact]
     public async Task DeleteTask_Existing_Returns204()
     {
@@ -205,7 +205,7 @@ public class TasksTests
         Assert.Equal(HttpStatusCode.NoContent, deleteResponse.StatusCode);
     }
 
-    // TC-TASK-09: Ștergere task inexistent → 404
+    // TC-TASK-09: Delete non-existing task → 404
     [Fact]
     public async Task DeleteTask_NonExisting_Returns404()
     {
@@ -218,7 +218,7 @@ public class TasksTests
 
     // ─── PATCH STATUS (Kanban) ────────────────────────────────────────────────
 
-    // TC-TASK-10: Schimbare status → InProgress (Kanban) → 200
+    // TC-TASK-10: Change status → InProgress (Kanban) → 200
     [Fact]
     public async Task PatchTask_StatusToInProgress_Returns200()
     {
@@ -233,7 +233,7 @@ public class TasksTests
         Assert.Equal(HttpStatusCode.OK, patchResponse.StatusCode);
     }
 
-    // TC-TASK-11: Schimbare status → Done (Kanban) → 200
+    // TC-TASK-11: Change status → Done (Kanban) → 200
     [Fact]
     public async Task PatchTask_StatusToDone_Returns200()
     {


### PR DESCRIPTION
## User Story
As a team member, I want all test comments to be in English so the codebase is consistent and readable for everyone.

## Changes
- Translated all Romanian comments to English in:
  - AuthTests.cs
  - TasksTests.cs
  - TasksFilterSortTests.cs
  - TasksOverdueTests.cs
  - SubjectsTests.cs

## Notes
No logic was changed — only comments and XML summaries were translated.