### PR TITLE
test(e2e): add Playwright E2E tests Fixes #68

### DIFF
--- a/frontend/e2e/auth.spec.ts
+++ b/frontend/e2e/auth.spec.ts
@@ -1,0 +1,78 @@
+import { test, expect, type Page } from '@playwright/test';
+
+async function clearAuth(page: Page) {
+  await page.goto('/');
+  await page.evaluate(() => localStorage.clear());
+}
+
+// TC-E2E-AUTH-01: Register with valid data → redirects to /tasks
+test('Register with valid data redirects to tasks page', async ({ page }) => {
+  const email = `test_${Date.now()}@taskmate.test`;
+
+  await page.goto('/register');
+  await page.waitForLoadState('networkidle');
+  await page.fill('input[name="email"]', email);
+  await page.fill('input[name="password"]', 'Password123!');
+  await page.fill('input[name="confirmPassword"]', 'Password123!');
+  await page.locator('form button').click();
+
+  await expect(page).toHaveURL(/\/(tasks|dashboard)/, { timeout: 15000 });
+});
+
+// TC-E2E-AUTH-02: Register with mismatched passwords → shows error
+test('Register with mismatched passwords shows error', async ({ page }) => {
+  await clearAuth(page);
+  await page.goto('/register');
+  await page.waitForLoadState('networkidle');
+  await page.fill('input[name="email"]', `test_${Date.now()}@taskmate.test`);
+  await page.fill('input[name="password"]', 'Password123!');
+  await page.fill('input[name="confirmPassword"]', 'Different123!');
+  await page.locator('form button').click();
+
+  await expect(page.locator('text=Passwords do not match')).toBeVisible();
+});
+
+// TC-E2E-AUTH-03: Login with valid credentials → redirects to /tasks
+test('Login with valid credentials redirects to tasks page', async ({ page }) => {
+  const email = `test_${Date.now()}@taskmate.test`;
+
+  await page.goto('/register');
+  await page.waitForLoadState('networkidle');
+  await page.fill('input[name="email"]', email);
+  await page.fill('input[name="password"]', 'Password123!');
+  await page.fill('input[name="confirmPassword"]', 'Password123!');
+  await page.locator('form button').click();
+  await expect(page).toHaveURL(/\/(tasks|dashboard)/, { timeout: 15000 });
+
+  await clearAuth(page);
+  await page.goto('/login');
+  await page.waitForLoadState('networkidle');
+  await page.fill('input[name="email"]', email);
+  await page.fill('input[name="password"]', 'Password123!');
+  await page.locator('form button').click();
+
+  await expect(page).toHaveURL(/\/(tasks|dashboard)/, { timeout: 15000 });
+});
+
+// TC-E2E-AUTH-04: Login with wrong password → shows error
+test('Login with wrong password shows error', async ({ page }) => {
+  const email = `test_${Date.now()}@taskmate.test`;
+
+  await page.goto('/register');
+  await page.waitForLoadState('networkidle');
+  await page.fill('input[name="email"]', email);
+  await page.fill('input[name="password"]', 'Password123!');
+  await page.fill('input[name="confirmPassword"]', 'Password123!');
+  await page.locator('form button').click();
+  await expect(page).toHaveURL(/\/(tasks|dashboard)/, { timeout: 15000 });
+
+  await clearAuth(page);
+  await page.goto('/login');
+  await page.waitForLoadState('networkidle');
+  await page.fill('input[name="email"]', email);
+  await page.fill('input[name="password"]', 'WrongPassword!');
+  await page.locator('form button').click();
+
+  await expect(page).toHaveURL(/\/login/, { timeout: 5000 });
+  await expect(page.locator('[class*="error"]').first()).toBeVisible({ timeout: 5000 });
+});

--- a/frontend/e2e/tasks.spec.ts
+++ b/frontend/e2e/tasks.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect, type Page } from '@playwright/test';
+
+async function clearAuth(page: Page) {
+  await page.goto('/');
+  await page.evaluate(() => localStorage.clear());
+}
+
+async function registerAndLogin(page: Page) {
+  const email = `test_${Date.now()}@taskmate.test`;
+  await clearAuth(page);
+  await page.goto('/register');
+  await page.waitForLoadState('networkidle');
+  await page.fill('input[name="email"]', email);
+  await page.fill('input[name="password"]', 'Password123!');
+  await page.fill('input[name="confirmPassword"]', 'Password123!');
+  await page.locator('form button').click();
+  await expect(page).toHaveURL(/\/(tasks|dashboard)/, { timeout: 15000 });
+}
+
+// TC-E2E-TASK-01: Create task → task appears on the board
+test('Create task appears on the board', async ({ page }) => {
+  await registerAndLogin(page);
+  await page.goto('/tasks');
+  await page.waitForLoadState('networkidle');
+
+  await page.click('text=+ Create Task');
+  await page.getByPlaceholder('Enter task title').fill('E2E Test Task');
+  await page.getByRole('button', { name: 'Create task', exact: true }).click();
+
+  await expect(page.locator('text=E2E Test Task')).toBeVisible({ timeout: 10000 });
+});
+
+// TC-E2E-TASK-02: Unauthenticated user is redirected to /login when accessing /tasks
+test('Unauthenticated user is redirected to login', async ({ page }) => {
+  await clearAuth(page);
+  await page.goto('/tasks');
+  await expect(page).toHaveURL(/\/login/, { timeout: 5000 });
+});
+
+// TC-E2E-TASK-03: Tasks page loads with Kanban board visible
+test('Tasks page shows Kanban board', async ({ page }) => {
+  await registerAndLogin(page);
+  await page.goto('/tasks');
+  await page.waitForLoadState('networkidle');
+
+  await expect(page.locator('text=+ Create Task')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Kanban' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'List' })).toBeVisible();
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,7 +20,8 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
-        "@types/node": "^24.12.0",
+        "@playwright/test": "^1.59.1",
+        "@types/node": "^24.12.2",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
@@ -690,6 +691,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@reduxjs/toolkit": {
@@ -2897,6 +2914,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
-    "@types/node": "^24.12.0",
+    "@playwright/test": "^1.59.1",
+    "@types/node": "^24.12.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: 'html',
+  timeout: 60000,
+  use: {
+    baseURL: process.env.FRONTEND_URL ?? 'http://localhost:5173',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});


### PR DESCRIPTION
## User Story
As a tester, I want to run automated E2E tests so that I can verify the full user flow works correctly in the browser.

## Changes
- Added Playwright E2E tests in `frontend/e2e/`:
  - `auth.spec.ts`: register, login, wrong password
  - `tasks.spec.ts`: create task, unauthenticated redirect, Kanban board
- Configured `playwright.config.ts` with base URL and 60s timeout

## Test Results
All 7 tests pass.

## Closes #68